### PR TITLE
Update use of 'master' to less offensive 'main'

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -5,9 +5,9 @@ name: (backend) Python application
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   build:

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -5,9 +5,9 @@ name: (frontend) Node.js CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   build:


### PR DESCRIPTION
I propose we change our default branch 'master', which has connotations with slavery, to the term 'main'.  I updated references to 'master' in the READMEs for both frontend and backend.  The one place I did not change is was in the serverless.yml file, which has "MasterUsername" and "MasterUserPassword" because I did not know the downstream effects of such a change.

Is there anyone else who should be reviewing this PR?  